### PR TITLE
Update Kotlin SDK link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Third-party SDKs created and maintained by the community.
 - [Gamemaker SDK](https://github.com/noellepunk/Neuro-Gamemaker-SDK)
 - [C SDK](https://github.com/xslendix/libneurosdk)
 - [Python SDK](https://github.com/CoolCat467/Neuro-API)
-- [Kotlin SDK](https://github.com/RedEpicness/neuro-game-sdk-kotlin)
+- [Kotlin SDK](https://github.com/RedEpicness/neuro-sdk-kotlin)
 - [C++ SDK](https://github.com/chris-pie/neuro-sdk-websocketpp)
 - [Generic C# SDK](https://github.com/pandapanda135/CSharp-Neuro-SDK)
 - [Ren'Py SDK](https://github.com/caheuer/neuro-renpy-implementation#for-developers)


### PR DESCRIPTION
Update link to Kotlin SDK due to a repository rename.