### PR TITLE
Add schema builders to Unity

### DIFF
--- a/Unity/Assets/Json/Builders.meta
+++ b/Unity/Assets/Json/Builders.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 421f1a31845b41e583b2e79a92788f17
+timeCreated: 1769705709

--- a/Unity/Assets/Json/Builders/ArrayBuilder.cs
+++ b/Unity/Assets/Json/Builders/ArrayBuilder.cs
@@ -3,17 +3,12 @@ using System.Collections.Generic;
 
 namespace NeuroSdk.Json.Builders
 {
-    public sealed class ArrayBuilder : SchemaBuilder<IEnumerator<object>>
+    public sealed class ArrayBuilder : SchemaBuilder
     {
-        public ArrayBuilder()
+        public ArrayBuilder(Func<JsonSchemaBuilders, SchemaBuilder> build)
         {
             Schema.Type = JsonSchemaType.Array;
-        }
-
-        public ArrayBuilder Items<TBuilder>(Func<JsonSchemaBuilders, SchemaBuilder<TBuilder>> build)
-        {
             Schema.Items = build(new JsonSchemaBuilders()).Build();
-            return this;
         }
 
         public ArrayBuilder MinItems(int value)

--- a/Unity/Assets/Json/Builders/ArrayBuilder.cs
+++ b/Unity/Assets/Json/Builders/ArrayBuilder.cs
@@ -1,17 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace NeuroSdk.Json.Builders
 {
-    public sealed class ArrayBuilder : SchemaBuilder
+    public sealed class ArrayBuilder : SchemaBuilder<IEnumerator<object>>
     {
         public ArrayBuilder()
         {
             Schema.Type = JsonSchemaType.Array;
         }
 
-        public ArrayBuilder Items(Func<SchemaBuilder> build)
+        public ArrayBuilder Items<TBuilder>(Func<JsonSchemaBuilders, SchemaBuilder<TBuilder>> build)
         {
-            Schema.Items = build().Build();
+            Schema.Items = build(JsonSchemaBuilders.Instance).Build();
             return this;
         }
 

--- a/Unity/Assets/Json/Builders/ArrayBuilder.cs
+++ b/Unity/Assets/Json/Builders/ArrayBuilder.cs
@@ -12,7 +12,7 @@ namespace NeuroSdk.Json.Builders
 
         public ArrayBuilder Items<TBuilder>(Func<JsonSchemaBuilders, SchemaBuilder<TBuilder>> build)
         {
-            Schema.Items = build(JsonSchemaBuilders.Instance).Build();
+            Schema.Items = build(new JsonSchemaBuilders()).Build();
             return this;
         }
 

--- a/Unity/Assets/Json/Builders/ArrayBuilder.cs
+++ b/Unity/Assets/Json/Builders/ArrayBuilder.cs
@@ -1,29 +1,29 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace NeuroSdk.Json.Builders
 {
-    public sealed class ArrayBuilder : SchemaBuilder
+    public sealed class ArrayBuilder<TItems> : SchemaBuilder<ArrayBuilder<TItems>>
+        where TItems : SchemaBuilder<TItems>
     {
-        public ArrayBuilder(Func<JsonSchemaBuilders, SchemaBuilder> build)
+        public ArrayBuilder(Func<JsonSchemaBuilders, SchemaBuilder<TItems>> build)
         {
             Schema.Type = JsonSchemaType.Array;
             Schema.Items = build(new JsonSchemaBuilders()).Build();
         }
 
-        public ArrayBuilder MinItems(int value)
+        public ArrayBuilder<TItems> MinItems(int value)
         {
             Schema.MinItems = value;
             return this;
         }
 
-        public ArrayBuilder MaxItems(int value)
+        public ArrayBuilder<TItems> MaxItems(int value)
         {
             Schema.MaxItems = value;
             return this;
         }
 
-        public ArrayBuilder UniqueItems(bool value = true)
+        public ArrayBuilder<TItems> UniqueItems(bool value = true)
         {
             Schema.UniqueItems = value;
             return this;

--- a/Unity/Assets/Json/Builders/ArrayBuilder.cs
+++ b/Unity/Assets/Json/Builders/ArrayBuilder.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace NeuroSdk.Json.Builders
+{
+    public sealed class ArrayBuilder : SchemaBuilder
+    {
+        public ArrayBuilder()
+        {
+            Schema.Type = JsonSchemaType.Array;
+        }
+
+        public ArrayBuilder Items(Func<SchemaBuilder> build)
+        {
+            Schema.Items = build().Build();
+            return this;
+        }
+
+        public ArrayBuilder MinItems(int value)
+        {
+            Schema.MinItems = value;
+            return this;
+        }
+
+        public ArrayBuilder MaxItems(int value)
+        {
+            Schema.MaxItems = value;
+            return this;
+        }
+
+        public ArrayBuilder UniqueItems(bool value = true)
+        {
+            Schema.UniqueItems = value;
+            return this;
+        }
+    }
+}

--- a/Unity/Assets/Json/Builders/ArrayBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/ArrayBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0646c51c54f045bb8f72b78cdd60757e
+timeCreated: 1769706057

--- a/Unity/Assets/Json/Builders/BooleanBuilder.cs
+++ b/Unity/Assets/Json/Builders/BooleanBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class BooleanBuilder : SchemaBuilder
+    public sealed class BooleanBuilder : SchemaBuilder<bool>
     {
         public BooleanBuilder()
         {

--- a/Unity/Assets/Json/Builders/BooleanBuilder.cs
+++ b/Unity/Assets/Json/Builders/BooleanBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class BooleanBuilder : PrimitiveBuilder<bool>
+    public sealed class BooleanBuilder : PrimitiveBuilder<BooleanBuilder, bool>
     {
         public BooleanBuilder()
         {

--- a/Unity/Assets/Json/Builders/BooleanBuilder.cs
+++ b/Unity/Assets/Json/Builders/BooleanBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class BooleanBuilder : SchemaBuilder<bool>
+    public sealed class BooleanBuilder : PrimitiveBuilder<bool>
     {
         public BooleanBuilder()
         {

--- a/Unity/Assets/Json/Builders/BooleanBuilder.cs
+++ b/Unity/Assets/Json/Builders/BooleanBuilder.cs
@@ -1,0 +1,10 @@
+﻿namespace NeuroSdk.Json.Builders
+{
+    public sealed class BooleanBuilder : SchemaBuilder
+    {
+        public BooleanBuilder()
+        {
+            Schema.Type = JsonSchemaType.Boolean;
+        }
+    }
+}

--- a/Unity/Assets/Json/Builders/BooleanBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/BooleanBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2491c82c290d4be1980ed585300b8aa8
+timeCreated: 1769706451

--- a/Unity/Assets/Json/Builders/FloatBuilder.cs
+++ b/Unity/Assets/Json/Builders/FloatBuilder.cs
@@ -1,0 +1,10 @@
+﻿namespace NeuroSdk.Json.Builders
+{
+    public sealed class FloatBuilder : NumberBuilder<FloatBuilder>
+    {
+        public FloatBuilder()
+        {
+            Schema.Type = JsonSchemaType.Float;
+        }
+    }
+}

--- a/Unity/Assets/Json/Builders/FloatBuilder.cs
+++ b/Unity/Assets/Json/Builders/FloatBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class FloatBuilder : NumberBuilder<FloatBuilder>
+    public sealed class FloatBuilder : NumberBuilder<FloatBuilder, float>
     {
         public FloatBuilder()
         {

--- a/Unity/Assets/Json/Builders/FloatBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/FloatBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f5761a21033646438267a0a1c003c5d3
+timeCreated: 1769706422

--- a/Unity/Assets/Json/Builders/IntegerBuilder.cs
+++ b/Unity/Assets/Json/Builders/IntegerBuilder.cs
@@ -1,0 +1,10 @@
+﻿namespace NeuroSdk.Json.Builders
+{
+    public sealed class IntegerBuilder : NumberBuilder<IntegerBuilder>
+    {
+        public IntegerBuilder()
+        {
+            Schema.Type = JsonSchemaType.Integer;
+        }
+    }
+}

--- a/Unity/Assets/Json/Builders/IntegerBuilder.cs
+++ b/Unity/Assets/Json/Builders/IntegerBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class IntegerBuilder : NumberBuilder<IntegerBuilder>
+    public sealed class IntegerBuilder : NumberBuilder<IntegerBuilder, int>
     {
         public IntegerBuilder()
         {

--- a/Unity/Assets/Json/Builders/IntegerBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/IntegerBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3c5b3ec78e004a918d35fecc70e9e34d
+timeCreated: 1769706309

--- a/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs
+++ b/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs
@@ -1,10 +1,17 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class JsonSchemaBuilders
+    public interface IRootSchemaBuilders
     {
-        public static JsonSchemaBuilders Instance { get; } = new();
+        ObjectBuilder Object();
+        ArrayBuilder Array();
+    }
+    
+    public sealed class JsonSchemaBuilders : IRootSchemaBuilders
+    {
+        // singleton schizophrenia xd
+        public static IRootSchemaBuilders Instance { get; } = new JsonSchemaBuilders();
 
-        private JsonSchemaBuilders() {}
+        internal JsonSchemaBuilders() {}
 
         public ObjectBuilder Object() => new();
         public ArrayBuilder Array() => new();

--- a/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs
+++ b/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs
@@ -1,9 +1,11 @@
-﻿namespace NeuroSdk.Json.Builders
+﻿using System;
+
+namespace NeuroSdk.Json.Builders
 {
     public interface IRootSchemaBuilders
     {
         ObjectBuilder Object();
-        ArrayBuilder Array();
+        ArrayBuilder Array(Func<JsonSchemaBuilders, SchemaBuilder> build);
     }
     
     public sealed class JsonSchemaBuilders : IRootSchemaBuilders
@@ -14,7 +16,7 @@
         internal JsonSchemaBuilders() {}
 
         public ObjectBuilder Object() => new();
-        public ArrayBuilder Array() => new();
+        public ArrayBuilder Array(Func<JsonSchemaBuilders, SchemaBuilder> build) => new(build);
         public StringBuilder String() => new();
         public IntegerBuilder Integer() => new();
         public FloatBuilder Float() => new();

--- a/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs
+++ b/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs
@@ -1,0 +1,18 @@
+﻿namespace NeuroSdk.Json.Builders
+{
+    public sealed class JsonSchemaBuilders
+    {
+        public static JsonSchemaBuilders Instance { get; } = new();
+
+        private JsonSchemaBuilders() {}
+
+        public ObjectBuilder Object() => new();
+        public ArrayBuilder Array() => new();
+        public StringBuilder String() => new();
+        public IntegerBuilder Integer() => new();
+        public FloatBuilder Float() => new();
+        public BooleanBuilder Boolean() => new();
+        public NullBuilder Null() => new();
+    }
+
+}

--- a/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs
+++ b/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs
@@ -5,23 +5,52 @@ namespace NeuroSdk.Json.Builders
     public interface IRootSchemaBuilders
     {
         ObjectBuilder Object();
-        ArrayBuilder Array(Func<JsonSchemaBuilders, SchemaBuilder> build);
+        ArrayBuilder<T> Array<T>(Func<JsonSchemaBuilders, SchemaBuilder<T>> build) where T : SchemaBuilder<T>;
     }
-    
+
     public sealed class JsonSchemaBuilders : IRootSchemaBuilders
     {
+        internal JsonSchemaBuilders()
+        {
+        }
+
         // singleton schizophrenia xd
         public static IRootSchemaBuilders Instance { get; } = new JsonSchemaBuilders();
 
-        internal JsonSchemaBuilders() {}
+        public ObjectBuilder Object()
+        {
+            return new ObjectBuilder();
+        }
 
-        public ObjectBuilder Object() => new();
-        public ArrayBuilder Array(Func<JsonSchemaBuilders, SchemaBuilder> build) => new(build);
-        public StringBuilder String() => new();
-        public IntegerBuilder Integer() => new();
-        public FloatBuilder Float() => new();
-        public BooleanBuilder Boolean() => new();
-        public NullBuilder Null() => new();
+        public ArrayBuilder<T> Array<T>(Func<JsonSchemaBuilders, SchemaBuilder<T>> build)
+            where T : SchemaBuilder<T>
+        {
+            return new ArrayBuilder<T>(build);
+        }
+
+        public StringBuilder String()
+        {
+            return new StringBuilder();
+        }
+
+        public IntegerBuilder Integer()
+        {
+            return new IntegerBuilder();
+        }
+
+        public FloatBuilder Float()
+        {
+            return new FloatBuilder();
+        }
+
+        public BooleanBuilder Boolean()
+        {
+            return new BooleanBuilder();
+        }
+
+        public NullBuilder Null()
+        {
+            return new NullBuilder();
+        }
     }
-
 }

--- a/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs.meta
+++ b/Unity/Assets/Json/Builders/JsonSchemaBuilders.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 634f56096f714031a8d9693680f2cc82
+timeCreated: 1769707387

--- a/Unity/Assets/Json/Builders/NullBuilder.cs
+++ b/Unity/Assets/Json/Builders/NullBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class NullBuilder : SchemaBuilder
+    public sealed class NullBuilder : SchemaBuilder<object>
     {
         public NullBuilder()
         {

--- a/Unity/Assets/Json/Builders/NullBuilder.cs
+++ b/Unity/Assets/Json/Builders/NullBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class NullBuilder : SchemaBuilder<object>
+    public sealed class NullBuilder : PrimitiveBuilder<object>
     {
         public NullBuilder()
         {

--- a/Unity/Assets/Json/Builders/NullBuilder.cs
+++ b/Unity/Assets/Json/Builders/NullBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class NullBuilder : PrimitiveBuilder<object>
+    public sealed class NullBuilder : PrimitiveBuilder<NullBuilder, object>
     {
         public NullBuilder()
         {

--- a/Unity/Assets/Json/Builders/NullBuilder.cs
+++ b/Unity/Assets/Json/Builders/NullBuilder.cs
@@ -1,0 +1,11 @@
+﻿namespace NeuroSdk.Json.Builders
+{
+    public sealed class NullBuilder : SchemaBuilder
+    {
+        public NullBuilder()
+        {
+            Schema.Type = JsonSchemaType.Null;
+            Schema.Const = null;
+        }
+    }
+}

--- a/Unity/Assets/Json/Builders/NullBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/NullBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: adbf731825984f4a9018c6821d104541
+timeCreated: 1769706539

--- a/Unity/Assets/Json/Builders/NumberBuilder.cs
+++ b/Unity/Assets/Json/Builders/NumberBuilder.cs
@@ -1,7 +1,7 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public abstract class NumberBuilder<TSelf> : SchemaBuilder<TSelf>
-        where TSelf : NumberBuilder<TSelf>
+    public abstract class NumberBuilder<TSelf, THolds> : PrimitiveBuilder<THolds>
+        where TSelf : NumberBuilder<TSelf, THolds>
     {
         protected TSelf Self => (TSelf)this;
 

--- a/Unity/Assets/Json/Builders/NumberBuilder.cs
+++ b/Unity/Assets/Json/Builders/NumberBuilder.cs
@@ -5,27 +5,27 @@
     {
         protected TSelf Self => (TSelf)this;
 
-        public TSelf Min(double value)
+        public TSelf Min(float value)
         {
-            Schema.Minimum = (float)value;
+            Schema.Minimum = value;
             return Self;
         }
 
-        public TSelf Max(double value)
+        public TSelf Max(float value)
         {
-            Schema.Maximum = (float)value;
+            Schema.Maximum = value;
             return Self;
         }
 
-        public TSelf ExclusiveMin(double value)
+        public TSelf ExclusiveMin(float value)
         {
-            Schema.ExclusiveMinimum = (float)value;
+            Schema.ExclusiveMinimum = value;
             return Self;
         }
 
-        public TSelf ExclusiveMax(double value)
+        public TSelf ExclusiveMax(float value)
         {
-            Schema.ExclusiveMaximum = (float)value;
+            Schema.ExclusiveMaximum = value;
             return Self;
         }
     }

--- a/Unity/Assets/Json/Builders/NumberBuilder.cs
+++ b/Unity/Assets/Json/Builders/NumberBuilder.cs
@@ -1,10 +1,8 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public abstract class NumberBuilder<TSelf, THolds> : PrimitiveBuilder<THolds>
+    public abstract class NumberBuilder<TSelf, THolds> : PrimitiveBuilder<TSelf, THolds>
         where TSelf : NumberBuilder<TSelf, THolds>
     {
-        protected TSelf Self => (TSelf)this;
-
         public TSelf Min(float value)
         {
             Schema.Minimum = value;

--- a/Unity/Assets/Json/Builders/NumberBuilder.cs
+++ b/Unity/Assets/Json/Builders/NumberBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public abstract class NumberBuilder<TSelf> : SchemaBuilder
+    public abstract class NumberBuilder<TSelf> : SchemaBuilder<TSelf>
         where TSelf : NumberBuilder<TSelf>
     {
         protected TSelf Self => (TSelf)this;

--- a/Unity/Assets/Json/Builders/NumberBuilder.cs
+++ b/Unity/Assets/Json/Builders/NumberBuilder.cs
@@ -1,0 +1,32 @@
+﻿namespace NeuroSdk.Json.Builders
+{
+    public abstract class NumberBuilder<TSelf> : SchemaBuilder
+        where TSelf : NumberBuilder<TSelf>
+    {
+        protected TSelf Self => (TSelf)this;
+
+        public TSelf Min(double value)
+        {
+            Schema.Minimum = (float)value;
+            return Self;
+        }
+
+        public TSelf Max(double value)
+        {
+            Schema.Maximum = (float)value;
+            return Self;
+        }
+
+        public TSelf ExclusiveMin(double value)
+        {
+            Schema.ExclusiveMinimum = (float)value;
+            return Self;
+        }
+
+        public TSelf ExclusiveMax(double value)
+        {
+            Schema.ExclusiveMaximum = (float)value;
+            return Self;
+        }
+    }
+}

--- a/Unity/Assets/Json/Builders/NumberBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/NumberBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9244035db93c4c13b8f830240f47befe
+timeCreated: 1769706268

--- a/Unity/Assets/Json/Builders/ObjectBuilder.cs
+++ b/Unity/Assets/Json/Builders/ObjectBuilder.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NeuroSdk.Json.Builders
+{
+    public sealed class ObjectBuilder : SchemaBuilder
+    {
+        public ObjectBuilder()
+        {
+            Schema.Type = JsonSchemaType.Object;
+            Schema.Properties = new Dictionary<string, JsonSchema>();
+        }
+
+        public ObjectBuilder Property(
+            string name,
+            Func<JsonSchemaBuilders, SchemaBuilder> build,
+            bool required = true)
+        {
+            var subBuilder = build(JsonSchemaBuilders.Instance);
+            Schema.Properties[name] = subBuilder.Build();
+
+            if (required)
+                Schema.Required.Add(name);
+
+            return this;
+        }
+
+    }
+}

--- a/Unity/Assets/Json/Builders/ObjectBuilder.cs
+++ b/Unity/Assets/Json/Builders/ObjectBuilder.cs
@@ -16,7 +16,7 @@ namespace NeuroSdk.Json.Builders
             Func<JsonSchemaBuilders, SchemaBuilder<TBuilder>> build,
             bool required = true)
         {
-            var subBuilder = build(JsonSchemaBuilders.Instance);
+            var subBuilder = build(new JsonSchemaBuilders());
             Schema.Properties[name] = subBuilder.Build();
 
             if (required)

--- a/Unity/Assets/Json/Builders/ObjectBuilder.cs
+++ b/Unity/Assets/Json/Builders/ObjectBuilder.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace NeuroSdk.Json.Builders
 {
-    public sealed class ObjectBuilder : SchemaBuilder
+    public sealed class ObjectBuilder : SchemaBuilder<ObjectBuilder>
     {
         public ObjectBuilder()
         {
@@ -11,19 +11,16 @@ namespace NeuroSdk.Json.Builders
             Schema.Properties = new Dictionary<string, JsonSchema>();
         }
 
-        public ObjectBuilder Property(
+        public ObjectBuilder Property<T>(
             string name,
-            Func<JsonSchemaBuilders, SchemaBuilder> build,
-            bool required = true)
+            Func<JsonSchemaBuilders, SchemaBuilder<T>> build) where T : SchemaBuilder<T>
         {
             var subBuilder = build(new JsonSchemaBuilders());
             Schema.Properties[name] = subBuilder.Build();
 
-            if (required)
-                Schema.Required.Add(name);
+            if (!subBuilder.IsOptional) Schema.Required.Add(name);
 
             return this;
         }
-
     }
 }

--- a/Unity/Assets/Json/Builders/ObjectBuilder.cs
+++ b/Unity/Assets/Json/Builders/ObjectBuilder.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace NeuroSdk.Json.Builders
 {
-    public sealed class ObjectBuilder : SchemaBuilder
+    public sealed class ObjectBuilder : SchemaBuilder<object>
     {
         public ObjectBuilder()
         {
@@ -11,9 +11,9 @@ namespace NeuroSdk.Json.Builders
             Schema.Properties = new Dictionary<string, JsonSchema>();
         }
 
-        public ObjectBuilder Property(
+        public ObjectBuilder Property<TBuilder>(
             string name,
-            Func<JsonSchemaBuilders, SchemaBuilder> build,
+            Func<JsonSchemaBuilders, SchemaBuilder<TBuilder>> build,
             bool required = true)
         {
             var subBuilder = build(JsonSchemaBuilders.Instance);

--- a/Unity/Assets/Json/Builders/ObjectBuilder.cs
+++ b/Unity/Assets/Json/Builders/ObjectBuilder.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace NeuroSdk.Json.Builders
 {
-    public sealed class ObjectBuilder : SchemaBuilder<object>
+    public sealed class ObjectBuilder : SchemaBuilder
     {
         public ObjectBuilder()
         {
@@ -11,9 +11,9 @@ namespace NeuroSdk.Json.Builders
             Schema.Properties = new Dictionary<string, JsonSchema>();
         }
 
-        public ObjectBuilder Property<TBuilder>(
+        public ObjectBuilder Property(
             string name,
-            Func<JsonSchemaBuilders, SchemaBuilder<TBuilder>> build,
+            Func<JsonSchemaBuilders, SchemaBuilder> build,
             bool required = true)
         {
             var subBuilder = build(new JsonSchemaBuilders());

--- a/Unity/Assets/Json/Builders/ObjectBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/ObjectBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ba10521db3994aaa839cf2450bfa2ae9
+timeCreated: 1769705803

--- a/Unity/Assets/Json/Builders/PrimitiveBuilder.cs
+++ b/Unity/Assets/Json/Builders/PrimitiveBuilder.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq;
+
+namespace NeuroSdk.Json.Builders
+{
+    public class PrimitiveBuilder<THolds> : SchemaBuilder
+    {
+        public PrimitiveBuilder<THolds> Const(THolds value)
+        {
+            Schema.Const = value;
+            return this;
+        }
+
+        public PrimitiveBuilder<THolds> Enum(params THolds[] values)
+        {
+            Schema.Enum = values.Cast<object>().ToList();
+            return this;
+        }
+    }
+}

--- a/Unity/Assets/Json/Builders/PrimitiveBuilder.cs
+++ b/Unity/Assets/Json/Builders/PrimitiveBuilder.cs
@@ -2,18 +2,19 @@
 
 namespace NeuroSdk.Json.Builders
 {
-    public class PrimitiveBuilder<THolds> : SchemaBuilder
+    public class PrimitiveBuilder<TSelf, THolds> : SchemaBuilder<TSelf>
+        where TSelf : PrimitiveBuilder<TSelf, THolds>
     {
-        public PrimitiveBuilder<THolds> Const(THolds value)
+        public TSelf Const(THolds value)
         {
             Schema.Const = value;
-            return this;
+            return Self;
         }
 
-        public PrimitiveBuilder<THolds> Enum(params THolds[] values)
+        public TSelf Enum(params THolds[] values)
         {
             Schema.Enum = values.Cast<object>().ToList();
-            return this;
+            return Self;
         }
     }
 }

--- a/Unity/Assets/Json/Builders/PrimitiveBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/PrimitiveBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2c36fd8332b240dc9c103ea7cba1603f
+timeCreated: 1769789104

--- a/Unity/Assets/Json/Builders/SchemaBuilder.cs
+++ b/Unity/Assets/Json/Builders/SchemaBuilder.cs
@@ -3,21 +3,21 @@ using System.Linq;
 
 namespace NeuroSdk.Json.Builders
 {
-    public class SchemaBuilder
+    public class SchemaBuilder<THolds>
     {
         protected readonly JsonSchema Schema = new();
 
         public JsonSchema Build() => Schema;
 
-        public SchemaBuilder Const(object value)
+        public SchemaBuilder<THolds> Const(object value)
         {
             Schema.Const = value;
             return this;
         }
 
-        public SchemaBuilder Enum(IEnumerable<object> values)
+        public SchemaBuilder<THolds> Enum(params THolds[] values)
         {
-            Schema.Enum = values.ToList();
+            Schema.Enum = values.Cast<object>().ToList();
             return this;
         }
     }

--- a/Unity/Assets/Json/Builders/SchemaBuilder.cs
+++ b/Unity/Assets/Json/Builders/SchemaBuilder.cs
@@ -1,24 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-namespace NeuroSdk.Json.Builders
+﻿namespace NeuroSdk.Json.Builders
 {
-    public class SchemaBuilder<THolds>
+    public class SchemaBuilder
     {
         protected readonly JsonSchema Schema = new();
 
         public JsonSchema Build() => Schema;
-
-        public SchemaBuilder<THolds> Const(object value)
-        {
-            Schema.Const = value;
-            return this;
-        }
-
-        public SchemaBuilder<THolds> Enum(params THolds[] values)
-        {
-            Schema.Enum = values.Cast<object>().ToList();
-            return this;
-        }
     }
 }

--- a/Unity/Assets/Json/Builders/SchemaBuilder.cs
+++ b/Unity/Assets/Json/Builders/SchemaBuilder.cs
@@ -7,6 +7,12 @@
 
         internal bool IsOptional { get; private set; }
 
+        public TSelf Description(string description)
+        {
+            Schema.Description = description;
+            return Self;
+        }
+
         public TSelf Optional()
         {
             IsOptional = true;

--- a/Unity/Assets/Json/Builders/SchemaBuilder.cs
+++ b/Unity/Assets/Json/Builders/SchemaBuilder.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace NeuroSdk.Json.Builders
+{
+    public class SchemaBuilder
+    {
+        protected readonly JsonSchema Schema = new();
+
+        public JsonSchema Build() => Schema;
+
+        public SchemaBuilder Const(object value)
+        {
+            Schema.Const = value;
+            return this;
+        }
+
+        public SchemaBuilder Enum(IEnumerable<object> values)
+        {
+            Schema.Enum = values.ToList();
+            return this;
+        }
+    }
+}

--- a/Unity/Assets/Json/Builders/SchemaBuilder.cs
+++ b/Unity/Assets/Json/Builders/SchemaBuilder.cs
@@ -1,9 +1,21 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public class SchemaBuilder
+    public class SchemaBuilder<TSelf> where TSelf : SchemaBuilder<TSelf>
     {
         protected readonly JsonSchema Schema = new();
+        protected TSelf Self => (TSelf)this;
 
-        public JsonSchema Build() => Schema;
+        internal bool IsOptional { get; private set; }
+
+        public TSelf Optional()
+        {
+            IsOptional = true;
+            return Self;
+        }
+
+        public JsonSchema Build()
+        {
+            return Schema;
+        }
     }
 }

--- a/Unity/Assets/Json/Builders/SchemaBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/SchemaBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1e61ee01018d419f9fccf8af4aa8aba7
+timeCreated: 1769705721

--- a/Unity/Assets/Json/Builders/StringBuilder.cs
+++ b/Unity/Assets/Json/Builders/StringBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class StringBuilder : PrimitiveBuilder<string>
+    public sealed class StringBuilder : PrimitiveBuilder<StringBuilder, string>
     {
         public StringBuilder()
         {

--- a/Unity/Assets/Json/Builders/StringBuilder.cs
+++ b/Unity/Assets/Json/Builders/StringBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class StringBuilder : SchemaBuilder
+    public sealed class StringBuilder : SchemaBuilder<object>
     {
         public StringBuilder()
         {

--- a/Unity/Assets/Json/Builders/StringBuilder.cs
+++ b/Unity/Assets/Json/Builders/StringBuilder.cs
@@ -1,0 +1,28 @@
+﻿namespace NeuroSdk.Json.Builders
+{
+    public sealed class StringBuilder : SchemaBuilder
+    {
+        public StringBuilder()
+        {
+            Schema.Type = JsonSchemaType.String;
+        }
+
+        public StringBuilder MinLength(int value)
+        {
+            Schema.MinLength = value;
+            return this;
+        }
+
+        public StringBuilder MaxLength(int value)
+        {
+            Schema.MaxLength = value;
+            return this;
+        }
+
+        public StringBuilder Pattern(string regex)
+        {
+            Schema.Pattern = regex;
+            return this;
+        }
+    }
+}

--- a/Unity/Assets/Json/Builders/StringBuilder.cs
+++ b/Unity/Assets/Json/Builders/StringBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace NeuroSdk.Json.Builders
 {
-    public sealed class StringBuilder : SchemaBuilder<object>
+    public sealed class StringBuilder : PrimitiveBuilder<string>
     {
         public StringBuilder()
         {

--- a/Unity/Assets/Json/Builders/StringBuilder.cs
+++ b/Unity/Assets/Json/Builders/StringBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace NeuroSdk.Json.Builders
+﻿using System.Text.RegularExpressions;
+
+namespace NeuroSdk.Json.Builders
 {
     public sealed class StringBuilder : PrimitiveBuilder<StringBuilder, string>
     {
@@ -22,6 +24,12 @@
         public StringBuilder Pattern(string regex)
         {
             Schema.Pattern = regex;
+            return this;
+        }
+
+        public StringBuilder Format(string format)
+        {
+            Schema.Format = format;
             return this;
         }
     }

--- a/Unity/Assets/Json/Builders/StringBuilder.cs.meta
+++ b/Unity/Assets/Json/Builders/StringBuilder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5e4f5688ef794ad084f3e09fb0e4a80b
+timeCreated: 1769706126

--- a/Unity/Assets/Json/JsonSchema.cs
+++ b/Unity/Assets/Json/JsonSchema.cs
@@ -113,6 +113,9 @@ namespace NeuroSdk.Json
 
         [JsonProperty("format")]
         public string? Format { get; set; }
+        
+        [JsonProperty("description")]
+        public string? Description { get; set; }
 
         #endregion
         

--- a/Unity/Assets/Json/QJS.cs
+++ b/Unity/Assets/Json/QJS.cs
@@ -66,6 +66,6 @@ namespace NeuroSdk.Json
             return result;
         }
 
-        public static JsonSchemaBuilders Builder => JsonSchemaBuilders.Instance;
+        public static IRootSchemaBuilders Builder => JsonSchemaBuilders.Instance;
     }
 }

--- a/Unity/Assets/Json/QJS.cs
+++ b/Unity/Assets/Json/QJS.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NeuroSdk.Json.Builders;
 
 namespace NeuroSdk.Json
 {
@@ -64,5 +65,7 @@ namespace NeuroSdk.Json
 
             return result;
         }
+
+        public static JsonSchemaBuilders Builder => JsonSchemaBuilders.Instance;
     }
 }


### PR DESCRIPTION
Adds a highly extensible and readable schema builder for the unity sdk.

Fully backward-compatible.

Here is an example with the old system:
```c#
protected override JsonSchema Schema =>
    QJS.WrapObject(
        new Dictionary<string, JsonSchema>
        {
            ["action"] = QJS.Enum(new[] { "move", "attack", "look_at" }),
            ["target"] = QJS.Type(JsonSchemaType.String),
            ["parameters"] = QJS.WrapObject(
                new Dictionary<string, JsonSchema>
                {
                    ["speed"] = QJS.Type(JsonSchemaType.Float),
                    ["direction"] = QJS.WrapObject(
                        new Dictionary<string, JsonSchema>
                        {
                            ["x"] = QJS.Type(JsonSchemaType.Float),
                            ["y"] = QJS.Type(JsonSchemaType.Float)
                        }
                    )
                },
                makePropertiesRequired: false
            ),
            ["flags"] = QJS.WrapObject(
                new Dictionary<string, JsonSchema>
                {
                    ["silent"] = QJS.Type(JsonSchemaType.Boolean)
                }
            )
        }
    );
``` 
and here is with the new builder system
```c#
protected override JsonSchema Schema =>
    QJS.Builder.Object()
        .Property("action", b => b.String().Enum("move", "attack", "look_at"))
        .Property("target", b => b.String())
        .Property("parameters", b => b.Object()
            .Property("speed", b => b.Float(), required: false)
            .Property("direction", b => b.Object()
                    .Property("x", b => b.Float())
                    .Property("y", b => b.Float()),
                required: false
            )
        )
        .Property("flags", b => b.Object()
            .Property("silent", b2 => b2.Boolean())
        )
        .Build();
``` 
In the base QJS wrapper you cannot make the root an array, so a little workaround would be:
```c#
protected override JsonSchema Schema => new JsonSchema
{
    Type = JsonSchemaType.Array,
    Items = new JsonSchema
    {
        Type = JsonSchemaType.Object,
        Properties = new Dictionary<string, JsonSchema>
        {
            ["id"] = new JsonSchema { Type = JsonSchemaType.Integer },
            ["name"] = new JsonSchema { Type = JsonSchemaType.String },
            ["tags"] = new JsonSchema
            {
                Type = JsonSchemaType.Array,
                Items = new JsonSchema { Type = JsonSchemaType.String }
            }
        },
        Required = new List<string> { "id", "name", "tags" }
    }
};
``` 
In the builders however, you can do that natively:
```c#
QJS.Builder
    .Array(b => b.Object()
        .Property("id", b => b.Integer())
        .Property("name", b => b.String())
        .Property("tags", b => b.Array()
                .Items(b => b.String())
        )
    )
    .Build();
``` 
---
All and all, with these changes along with my other pull requests, this should help encourage making proper schemas and give better information to neuro so she can better understand how the data should be formed