### PR TITLE
Add utility methods to ActionJData in Unity

### DIFF
--- a/Unity/Assets/Actions/ActionJData.cs
+++ b/Unity/Assets/Actions/ActionJData.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
 using NeuroSdk.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
@@ -46,107 +45,5 @@ namespace NeuroSdk.Actions
                 return false;
             }
         }
-        
-        #region Utility
-
-        public T? Get<T>(string path, T? defaultValue = default)
-        {
-            return TryGet(path, out T? value) ? value : defaultValue;
-        }
-
-        public bool TryGet<T>(string path, out T? value)
-        {
-            value = default;
-
-            var token = Data?.SelectToken(path);
-            if (token is null || token.Type == JTokenType.Null)
-                return false;
-
-            try
-            {
-                value = token.ToObject<T>();
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        public string? GetString(string path, string? defaultValue = null) => Get(path, defaultValue);
-        public bool TryGetString(string path, out string? value) => TryGet(path, out value);
-
-        public int GetInt(string path, int defaultValue = 0) => Get(path, defaultValue);
-        public bool TryGetInt(string path, out int value)
-        {
-            value = 0;
-            if (!TryGet(path, out int? val)) return false;
-            
-            value = val.GetValueOrDefault();
-            return true;
-        }
-
-        public float GetFloat(string path, float defaultValue = 0f) => Get(path, defaultValue);
-        public bool TryGetFloat(string path, out float value)
-        {
-            value = 0f;
-            if (!TryGet(path, out float? val)) return false;
-            
-            value = val.GetValueOrDefault();
-            return true;
-        }
-
-        public bool GetBool(string path, bool defaultValue = false) => Get(path, defaultValue);
-        public bool TryGetBool(string path, out bool value)
-        {
-            value = false;
-            if (!TryGet(path, out bool? val)) return false;
-            
-            value = val.GetValueOrDefault();
-            return true;
-        }
-
-        public JObject? GetObject(string path) => Get<JObject>(path);
-        public bool TryGetObject(string path, out JObject? obj)
-        {
-            obj = null;
-            if (Data?.SelectToken(path) is not JObject token) return false;
-            
-            obj = token;
-            return true;
-        }
-        
-        public JArray? GetArray(string path) => Get<JArray>(path);
-        public bool TryGetArray(string path, out JArray? array)
-        {
-            array = null;
-            if (Data?.SelectToken(path) is not JArray token) return false;
-            
-            array = token;
-            return true;
-        }
-
-        public bool Contains(string path) => Data?.SelectToken(path) != null;
-        public bool HasValue(string path) => Data?.SelectToken(path) is { Type: not JTokenType.Null };
-        public bool IsNull(string path) => Data?.SelectToken(path)?.Type == JTokenType.Null;
-
-        public Dictionary<string, object>? ToDictionary() => Data?.ToObject<Dictionary<string, object>>();
-        
-        public JToken? DeepCopy() => Data?.DeepClone();
-        public T? ToObject<T>()
-        {
-            if (Data == null) return default;
-
-            try
-            {
-                return Data.ToObject<T>();
-            }
-            catch
-            {
-                return default;
-            } 
-        }
-
-        #endregion
     }
 }

--- a/Unity/Assets/Actions/ActionJData.cs
+++ b/Unity/Assets/Actions/ActionJData.cs
@@ -100,16 +100,31 @@ namespace NeuroSdk.Actions
         public bool TryGetBool(string path, out bool value)
         {
             value = false;
-            if (TryGet(path, out bool? val))
-            {
-                value = val.GetValueOrDefault();
-                return true;
-            }
-            return false;
+            if (!TryGet(path, out bool? val)) return false;
+            
+            value = val.GetValueOrDefault();
+            return true;
         }
 
         public JObject? GetObject(string path) => Get<JObject>(path);
+        public bool TryGetObject(string path, out JObject? obj)
+        {
+            obj = null;
+            if (Data?.SelectToken(path) is not JObject token) return false;
+            
+            obj = token;
+            return true;
+        }
+        
         public JArray? GetArray(string path) => Get<JArray>(path);
+        public bool TryGetArray(string path, out JArray? array)
+        {
+            array = null;
+            if (Data?.SelectToken(path) is not JArray token) return false;
+            
+            array = token;
+            return true;
+        }
 
         public bool Contains(string path) => Data?.SelectToken(path) != null;
         public bool HasValue(string path) => Data?.SelectToken(path) is { Type: not JTokenType.Null };

--- a/Unity/Assets/Actions/ActionJData.cs
+++ b/Unity/Assets/Actions/ActionJData.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Collections.Generic;
 using NeuroSdk.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
@@ -45,5 +46,92 @@ namespace NeuroSdk.Actions
                 return false;
             }
         }
+        
+        #region Utility
+
+        public T? Get<T>(string path, T? defaultValue = default)
+        {
+            return TryGet(path, out T? value) ? value : defaultValue;
+        }
+
+        public bool TryGet<T>(string path, out T? value)
+        {
+            value = default;
+
+            var token = Data?.SelectToken(path);
+            if (token is null || token.Type == JTokenType.Null)
+                return false;
+
+            try
+            {
+                value = token.ToObject<T>();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public string? GetString(string path, string? defaultValue = null) => Get(path, defaultValue);
+        public bool TryGetString(string path, out string? value) => TryGet(path, out value);
+
+        public int GetInt(string path, int defaultValue = 0) => Get(path, defaultValue);
+        public bool TryGetInt(string path, out int value)
+        {
+            value = 0;
+            if (!TryGet(path, out int? val)) return false;
+            
+            value = val.GetValueOrDefault();
+            return true;
+        }
+
+        public float GetFloat(string path, float defaultValue = 0f) => Get(path, defaultValue);
+        public bool TryGetFloat(string path, out float value)
+        {
+            value = 0f;
+            if (!TryGet(path, out float? val)) return false;
+            
+            value = val.GetValueOrDefault();
+            return true;
+        }
+
+        public bool GetBool(string path, bool defaultValue = false) => Get(path, defaultValue);
+        public bool TryGetBool(string path, out bool value)
+        {
+            value = false;
+            if (TryGet(path, out bool? val))
+            {
+                value = val.GetValueOrDefault();
+                return true;
+            }
+            return false;
+        }
+
+        public JObject? GetObject(string path) => Get<JObject>(path);
+        public JArray? GetArray(string path) => Get<JArray>(path);
+
+        public bool Contains(string path) => Data?.SelectToken(path) != null;
+        public bool HasValue(string path) => Data?.SelectToken(path) is { Type: not JTokenType.Null };
+        public bool IsNull(string path) => Data?.SelectToken(path)?.Type == JTokenType.Null;
+
+        public Dictionary<string, object>? ToDictionary() => Data?.ToObject<Dictionary<string, object>>();
+        
+        public JToken? DeepCopy() => Data?.DeepClone();
+        public T? ToObject<T>()
+        {
+            if (Data == null) return default;
+
+            try
+            {
+                return Data.ToObject<T>();
+            }
+            catch
+            {
+                return default;
+            } 
+        }
+
+        #endregion
     }
 }

--- a/Unity/Assets/Json/JTokenWrapperExtensions.cs
+++ b/Unity/Assets/Json/JTokenWrapperExtensions.cs
@@ -1,28 +1,108 @@
 ﻿#nullable enable
 
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json.Linq;
 
 namespace NeuroSdk.Json
 {
     public static class JTokenWrapperExtensions
     {
-        public static T? GetValue<T>(this IJTokenWrapper data, string key, T? defaultValue)
+        public static T? Get<T>(this IJTokenWrapper data, string path, T? defaultValue = default)
         {
-            JToken? jToken = data.Data?[key];
-            return jToken != null ? jToken.Value<T>() : defaultValue;
+            return data.TryGet(path, out T? value) ? value : defaultValue;
         }
 
-        public static T? GetValue<T>(this IJTokenWrapper data, string key) where T : class
+        public static bool TryGet<T>(this IJTokenWrapper data, string path, out T? value)
         {
-            JToken? jToken = data.Data?[key];
-            return jToken?.Value<T>();
+            value = default;
+
+            var token = data.Data?.SelectToken(path);
+            if (token is null || token.Type == JTokenType.Null)
+                return false;
+
+            try
+            {
+                value = token.ToObject<T>();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
-        public static IEnumerable<T?> GetArray<T>(this IJTokenWrapper data, string key)
+        public static string? GetString(this IJTokenWrapper data, string path, string? defaultValue = null) => data.Get(path, defaultValue);
+        public static bool TryGetString(this IJTokenWrapper data, string path, out string? value) => data.TryGet(path, out value);
+
+        public static int GetInt(this IJTokenWrapper data, string path, int defaultValue = 0) => data.Get(path, defaultValue);
+        public static bool TryGetInt(this IJTokenWrapper data, string path, out int value)
         {
-            return data.Data?[key]?.Values<T?>() ?? Enumerable.Empty<T?>();
+            value = 0;
+            if (!data.TryGet(path, out int? val)) return false;
+            
+            value = val.GetValueOrDefault();
+            return true;
+        }
+
+        public static float GetFloat(this IJTokenWrapper data, string path, float defaultValue = 0f) => data.Get(path, defaultValue);
+        public static bool TryGetFloat(this IJTokenWrapper data, string path, out float value)
+        {
+            value = 0f;
+            if (!data.TryGet(path, out float? val)) return false;
+            
+            value = val.GetValueOrDefault();
+            return true;
+        }
+
+        public static bool GetBool(this IJTokenWrapper data, string path, bool defaultValue = false) => data.Get(path, defaultValue);
+        public static bool TryGetBool(this IJTokenWrapper data, string path, out bool value)
+        {
+            value = false;
+            if (!data.TryGet(path, out bool? val)) return false;
+            
+            value = val.GetValueOrDefault();
+            return true;
+        }
+
+        public static JObject? GetObject(this IJTokenWrapper data, string path) => data.Get<JObject>(path);
+        public static bool TryGetObject(this IJTokenWrapper data, string path, out JObject? obj)
+        {
+            obj = null;
+            if (data.Data?.SelectToken(path) is not JObject token) return false;
+            
+            obj = token;
+            return true;
+        }
+        
+        public static JArray? GetArray(this IJTokenWrapper data, string path) => data.Get<JArray>(path);
+        public static bool TryGetArray(this IJTokenWrapper data, string path, out JArray? array)
+        {
+            array = null;
+            if (data.Data?.SelectToken(path) is not JArray token) return false;
+            
+            array = token;
+            return true;
+        }
+
+        public static bool Contains(this IJTokenWrapper data, string path) => data.Data?.SelectToken(path) != null;
+        public static bool HasValue(this IJTokenWrapper data, string path) => data.Data?.SelectToken(path) is { Type: not JTokenType.Null };
+        public static bool IsNull(this IJTokenWrapper data, string path) => data.Data?.SelectToken(path)?.Type == JTokenType.Null;
+
+        public static Dictionary<string, object>? ToDictionary(this IJTokenWrapper data) => data.Data?.ToObject<Dictionary<string, object>>();
+        
+        public static JToken? DeepCopy(this IJTokenWrapper data) => data.Data?.DeepClone();
+        public static T? ToObject<T>(this IJTokenWrapper data)
+        {
+            if (data.Data == null) return default;
+
+            try
+            {
+                return data.Data.ToObject<T>();
+            }
+            catch
+            {
+                return default;
+            } 
         }
     }
 }

--- a/Unity/Assets/Messages/Incoming/Action.cs
+++ b/Unity/Assets/Messages/Incoming/Action.cs
@@ -32,7 +32,7 @@ namespace NeuroSdk.Messages.Incoming
                 return ExecutionResult.VedalFailure(NeuroSdkStrings.ActionFailedNoData);
             }
 
-            string? id = messageData.GetValue<string>("id");
+            string? id = messageData.GetString("id");
 
             if (id is null or "")
             {
@@ -44,8 +44,8 @@ namespace NeuroSdk.Messages.Incoming
 
             try
             {
-                string? name = messageData.GetValue<string>("name");
-                string? stringifiedData = messageData.GetValue<string>("data");
+                string? name = messageData.GetString("name");
+                string? stringifiedData = messageData.GetString("data");
 
                 if (name is null or "") return ExecutionResult.VedalFailure(NeuroSdkStrings.ActionFailedNoName);
 


### PR DESCRIPTION
Some new utility methods to ActionJData for ease of use.

Also, this PR introduces breaking changes for people using the GetValue\<T> method, as it has now been replaced with more intuitive counterparts.

Before:
```c#
var target = (string?)actionData.Data?["target"];
var targetInfo = (string?)actionData.Data?["target"]?["info"];
var speed = (float?)actionData.Data?["parameters"]?["speed"];
var isSilent = (bool?)actionData.Data?["flags"]?["silent"];
var enemies = (JArray?)actionData.Data?["enemies"];
``` 
After:
```c#
var target = actionData.GetString("target");
var targetInfo = actionData.GetString("target.info");
var speed = actionData.GetFloat("parameters.speed");
var isSilent = actionData.GetBool("flags.silent");
var enemies = actionData.GetArray("enemies");
``` 
and some other examples
```c#
// nested object
var stats = actionData.GetObject("player.stats");

// array index access
var firstEnemyName = actionData.GetString("enemies[0].name");
var secondValue = actionData.GetFloat("parameters.values[1]");

// default values
var retries = actionData.GetInt("parameters.retries", 3);
var timeout = actionData.GetFloat("parameters.timeout", 5f);

// safe TryGet methods
if (actionData.TryGetString("optional.note", out var note))
{
    Debug.Log($"Note: {note}");
}

// check existence
if (actionData.Contains("target.position"))
{
    var position = actionData.GetObject("target.position");
}

// null checks
if (!actionData.IsNull("flags.override"))
{
    var overrideFlag = actionData.GetBool("flags.override");
}
```
---
All and all, with these changes along with my other pull requests, this should help encourage safer validation and data access code.
