### PR TITLE
Add RPG Maker VX Ace SDK to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Third-party SDKs created and maintained by the community.
 - [C++ SDK](https://github.com/chris-pie/neuro-sdk-websocketpp)
 - [Generic C# SDK](https://github.com/pandapanda135/CSharp-Neuro-SDK)
 - [Ren'Py SDK](https://github.com/caheuer/neuro-renpy-implementation#for-developers)
-- [RPG Maker VX Ace SDK](https://github.com/Pasu4/rpg-maker-neuro-sdk)
+- [RPG Maker VX Ace SDK](https://github.com/Pasu4/rpg-maker-vxa-neuro-sdk)
 
 ### Tools
 - [Tony](https://github.com/Pasu4/neuro-api-tony) is a graphical testing interface, similar to Randy, but it allows the user to write messages manually.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Third-party SDKs created and maintained by the community.
 - [C++ SDK](https://github.com/chris-pie/neuro-sdk-websocketpp)
 - [Generic C# SDK](https://github.com/pandapanda135/CSharp-Neuro-SDK)
 - [Ren'Py SDK](https://github.com/caheuer/neuro-renpy-implementation#for-developers)
+- [RPG Maker VX Ace SDK](https://github.com/Pasu4/rpg-maker-neuro-sdk)
 
 ### Tools
 - [Tony](https://github.com/Pasu4/neuro-api-tony) is a graphical testing interface, similar to Randy, but it allows the user to write messages manually.


### PR DESCRIPTION
I made a Neuro SDK for [RPG Maker VX Ace](https://www.rpgmakerweb.com/products/rpg-maker-vx-ace). It supports all current functions of the API, but I'm also working on a "general integration" that would make creating/integrating basic games made with the engine easier. The repo is [here](https://github.com/Pasu4/rpg-maker-vxa-neuro-sdk).

Due to technical limitations, the SDK comes in two parts, Ruby scripts for RPG Maker and a JavaScript-based proxy server. The proxy uses a TCP socket to communicate with the game. Otherwise it just passes through the JSON data from the API to the game and vice versa.