### PR TITLE
Implement Speech finished in Godot and Unity SDKs

### DIFF
--- a/Godot/USAGE.md
+++ b/Godot/USAGE.md
@@ -12,7 +12,7 @@ After the websocket startup acknowledgement arrives, the `Websocket` autoload ex
 
 ## Handling Speaking State
 
-Once a `speech_finished` message has been sent, the `Websocket` autoload sets `is_finished`, `speech_cancelled` and `speech_reason`. You can also connect to `Websocket.speech_finished` to react to messages as they are sent. If you need active monitoring of the state, this is the recommended approach, as multiple messages can be sent during a single response.
+Once a `speech_finished` message has been sent, the `Websocket` autoload sets `is_final`, `speech_cancelled` and `speech_reason`. You can also connect to `Websocket.speech_finished` to react to messages as they are sent. If you need active monitoring of the state, this is the recommended approach, as multiple messages can be sent during a single response.
 
 ## Voice Chat
 

--- a/Godot/USAGE.md
+++ b/Godot/USAGE.md
@@ -10,6 +10,10 @@ For sending context messages, you can use the `Context.send(message: String, sil
 
 After the websocket startup acknowledgement arrives, the `Websocket` autoload exposes `character_id` and `character_display_name`. You can also connect to the `Websocket.character_changed` signal if you need to react when that metadata becomes available.
 
+## Handling Speaking State
+
+Once a `speech_finished` message has been sent, the `Websocket` autoload sets `is_finished`, `speech_cancelled` and `speech_reason`. You can also connect to `Websocket.speech_finished` to react to messages as they are sent. If you need active monitoring of the state, this is the recommended approach, as multiple messages can be sent during a single response.
+
 ## Voice Chat
 
 If your game has built-in voice chat, you can optionally use the `NeuroVoiceChat` node to let Neuro hear and talk to the other players through it. See the [voice chat API documentation](../API/VOICE_CHAT.md) for how the underlying protocol works and what is expected of your integration.

--- a/Godot/addons/neuro-sdk/messages/incoming/speech_finished.gd
+++ b/Godot/addons/neuro-sdk/messages/incoming/speech_finished.gd
@@ -5,12 +5,10 @@ func _can_handle(command: String) -> bool:
 	return command == "speech_finished"
 
 func _validate(_command: String, message_data: IncomingData, state: Dictionary) -> ExecutionResult:
-	var data := message_data.get_object("data", {})
-	
-	var is_final := data.get_boolean("isFinal")
-	var cancelled := data.get_boolean("cancelled")
-	var reason := data.get_string("reason")
-	
+	var is_final := message_data.get_boolean("isFinal")
+	var cancelled := message_data.get_boolean("cancelled")
+	var reason := message_data.get_string("reason")
+
 	state["isFinal"] = is_final
 	state["cancelled"] = cancelled
 	state["reason"] = reason

--- a/Godot/addons/neuro-sdk/messages/incoming/speech_finished.gd
+++ b/Godot/addons/neuro-sdk/messages/incoming/speech_finished.gd
@@ -1,0 +1,26 @@
+class_name SpeechFinished
+extends IncomingMessage
+
+func _can_handle(command: String) -> bool:
+	return command == "speech_finished"
+
+func _validate(_command: String, message_data: IncomingData, state: Dictionary) -> ExecutionResult:
+	var data := message_data.get_object("data", {})
+	
+	var is_final := data.get_boolean("isFinal")
+	var cancelled := data.get_boolean("cancelled")
+	var reason := data.get_string("reason")
+	
+	state["isFinal"] = is_final
+	state["cancelled"] = cancelled
+	state["reason"] = reason
+	return ExecutionResult.success()
+
+func _report_result(_state: Dictionary, _result: ExecutionResult) -> void:
+	pass
+
+func _execute(state: Dictionary) -> void:
+	var is_final := state.get("isFinal")
+	var cancelled := state.get("cancelled")
+	var reason := state.get("reason")
+	Websocket.set_speech_finished(is_final, cancelled, reason)

--- a/Godot/addons/neuro-sdk/websocket/websocket.gd
+++ b/Godot/addons/neuro-sdk/websocket/websocket.gd
@@ -5,7 +5,7 @@ signal connected
 signal connection_failed(error: Error)
 signal disconnected(code: int)
 signal character_changed(character_id: String, display_name: String)
-signal speech_finished(is_finished: bool, cancelled: bool, reason: String)
+signal speech_finished(is_final: bool, cancelled: bool, reason: String)
 
 const POLL_INTERVAL := 1.0 / 30.0
 const RECONNECT_INTERVAL := 3.0
@@ -140,7 +140,8 @@ func set_speech_finished(new_final: bool, new_cancelled: bool, new_reason: Strin
 	is_final = new_final
 	speech_cancelled = new_cancelled
 	speech_reason = new_reason
-	speech_finished.emit(is_final, speech_cancelled, speech_reason)
+	if is_final:
+		speech_finished.emit(is_final, speech_cancelled, speech_reason)
 
 
 func send_immediate(message: OutgoingMessage) -> void:

--- a/Godot/addons/neuro-sdk/websocket/websocket.gd
+++ b/Godot/addons/neuro-sdk/websocket/websocket.gd
@@ -5,6 +5,7 @@ signal connected
 signal connection_failed(error: Error)
 signal disconnected(code: int)
 signal character_changed(character_id: String, display_name: String)
+signal speech_finished(is_finished: bool, cancelled: bool, reason: String)
 
 const POLL_INTERVAL := 1.0 / 30.0
 const RECONNECT_INTERVAL := 3.0
@@ -17,6 +18,9 @@ var _elapsed_time := 0.0
 var websocket_is_connected: bool = false
 var character_id: String = ""
 var character_display_name: String = ""
+var is_final: bool = false
+var speech_cancelled: bool = false
+var speech_reason: String = ""
 
 
 func _enter_tree() -> void:
@@ -130,6 +134,13 @@ func set_character_metadata(new_character_id: String, new_display_name: String) 
 	character_id = new_character_id
 	character_display_name = new_display_name if new_display_name != "" else new_character_id
 	character_changed.emit(character_id, character_display_name)
+
+
+func set_speech_finished(new_final: bool, new_cancelled: bool, new_reason: String) -> void:
+	is_final = new_final
+	speech_cancelled = new_cancelled
+	speech_reason = new_reason
+	speech_finished.emit(is_final, speech_cancelled, speech_reason)
 
 
 func send_immediate(message: OutgoingMessage) -> void:

--- a/Unity/Assets/Messages/Incoming/SpeechFinished.cs
+++ b/Unity/Assets/Messages/Incoming/SpeechFinished.cs
@@ -29,13 +29,12 @@ namespace NeuroSdk.Messages.Incoming
 			out ParsedData? parsedData)
 		{
 			parsedData = null;
+			
+			if (messageData.Data is not JObject root) return ExecutionResult.Success();
 
-			if (messageData.Data is not JObject root || root["data"] is not JObject data)
-				return ExecutionResult.Success();
-
-			bool isFinal = data.Value<bool>("isFinal");
-			bool? cancelled = data.Value<bool?>("cancelled");
-			string? reason = data.Value<string?>("reason");
+			bool isFinal = root.Value<bool>("isFinal");
+			bool? cancelled = root.Value<bool?>("cancelled");
+			string? reason = root.Value<string?>("reason");
 
 			parsedData = new ParsedData(isFinal, cancelled, reason);
 			return ExecutionResult.Success();

--- a/Unity/Assets/Messages/Incoming/SpeechFinished.cs
+++ b/Unity/Assets/Messages/Incoming/SpeechFinished.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+using NeuroSdk.Messages.API;
+using NeuroSdk.Websocket;
+using Newtonsoft.Json.Linq;
+
+namespace NeuroSdk.Messages.Incoming
+{
+	// ReSharper disable once UnusedType.Global
+	public sealed class SpeechFinished : IncomingMessageHandler<SpeechFinished.ParsedData>
+	{
+		public sealed class ParsedData
+		{
+			public ParsedData(bool isFinal, bool? cancelled, string? reason)
+			{
+				IsFinal = isFinal;
+				Cancelled = cancelled;
+				Reason = reason;
+			}
+
+			public bool IsFinal { get; }
+			public bool? Cancelled { get; }
+			public string? Reason { get; }
+		}
+
+		public override bool CanHandle(string command) => command == "speech_finished";
+
+		protected override ExecutionResult Validate(string command, MessageJData messageData,
+			out ParsedData? parsedData)
+		{
+			parsedData = null;
+
+			if (messageData.Data is not JObject root || root["data"] is not JObject data)
+				return ExecutionResult.Success();
+
+			bool isFinal = data.Value<bool>("isFinal");
+			bool? cancelled = data.Value<bool?>("cancelled");
+			string? reason = data.Value<string?>("reason");
+
+			parsedData = new ParsedData(isFinal, cancelled, reason);
+			return ExecutionResult.Success();
+		}
+
+		protected override void ReportResult(ParsedData? parsedData, ExecutionResult result)
+		{
+		}
+
+		protected override void Execute(ParsedData? parsedData)
+		{
+			if (parsedData == null) return;
+			WebsocketConnection.Instance?.SetSpeechFinished(
+				new SpeechFinishedResult(parsedData.IsFinal, parsedData.Cancelled, parsedData.Reason)
+			);
+		}
+	}
+}

--- a/Unity/Assets/Messages/Incoming/SpeechFinished.cs.meta
+++ b/Unity/Assets/Messages/Incoming/SpeechFinished.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d91c8eb5305ee46d7869370ce7c83053

--- a/Unity/Assets/Messages/Incoming/SpeechFinished.cs.meta
+++ b/Unity/Assets/Messages/Incoming/SpeechFinished.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: d91c8eb5305ee46d7869370ce7c83053
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/Assets/Websocket/WebsocketConnection.cs
+++ b/Unity/Assets/Websocket/WebsocketConnection.cs
@@ -237,7 +237,10 @@ namespace NeuroSdk.Websocket
         public void SetSpeechFinished(SpeechFinishedResult result)
         {
             SpeechFinished = result;
-            onSpeechFinished?.Invoke(result);
+            if (SpeechFinished.IsFinal)
+            {
+                onSpeechFinished?.Invoke(result);
+            }
         }
 
         [Il2CppHide]

--- a/Unity/Assets/Websocket/WebsocketConnection.cs
+++ b/Unity/Assets/Websocket/WebsocketConnection.cs
@@ -26,6 +26,20 @@ namespace NeuroSdk.Websocket
         public string DisplayName { get; }
     }
 
+    public sealed class SpeechFinishedResult
+    {
+        public SpeechFinishedResult(bool isFinal, bool? cancelled, string? reason)
+        {
+            IsFinal = isFinal;
+            Cancelled = cancelled;
+            Reason = reason;
+        }
+        
+        public bool IsFinal { get; }
+        public bool? Cancelled { get; }
+        public string? Reason { get; }
+    }
+
 #pragma warning disable CS0618 // Type or member is obsolete
     [RegisterInIl2Cpp]
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -53,11 +67,13 @@ namespace NeuroSdk.Websocket
         public MessageQueue messageQueue = null!;
         public CommandHandler commandHandler = null!;
         public CharacterMetadata? Character { get; private set; }
+        public SpeechFinishedResult? SpeechFinished { get; private set; }
 
         public UnityEvent? onConnected;
         public UnityEvent<string>? onError;
         public UnityEvent<WebSocketCloseCode>? onDisconnected;
         public UnityEvent<CharacterMetadata>? onCharacterChanged;
+        public UnityEvent<SpeechFinishedResult>? onSpeechFinished;
 
         private void Awake()
         {
@@ -215,6 +231,13 @@ namespace NeuroSdk.Websocket
         {
             Character = metadata;
             onCharacterChanged?.Invoke(metadata);
+        }
+
+        [Il2CppHide]
+        public void SetSpeechFinished(SpeechFinishedResult result)
+        {
+            SpeechFinished = result;
+            onSpeechFinished?.Invoke(result);
         }
 
         [Il2CppHide]

--- a/Unity/USAGE.md
+++ b/Unity/USAGE.md
@@ -10,6 +10,11 @@ For sending context messages, you can use the `static void Context.Send(string m
 
 After the websocket startup acknowledgement arrives, `WebsocketConnection.Instance.Character` contains the connected character's `CharacterId` and `DisplayName`. You can also listen to `WebsocketConnection.onCharacterChanged` if you need to react when that metadata becomes available.
 
+## Handling Speaking State
+
+Once a `speech_finished` message has been sent, `WebsocketConnection.Instance.SpeechFinished` will contain the result of the message. You can also listen to 
+`WebsocketConnection.onSpeechFinished` to react to the messages as they are sent. This is the recommended approach as multiple messages can be sent during a single response.
+
 ## Voice Chat
 
 If your game has built-in voice chat, you can optionally use `NeuroSdk.Voice.NeuroVoiceChat` to let Neuro hear and talk to the other players through it. See the [voice chat API documentation](../API/VOICE_CHAT.md) for how the underlying protocol works and what is expected of your integration.


### PR DESCRIPTION
This adds events (signals in Godot) and members to the websocket singletons of both the Unity and Godot SDKs exposing the speech finished message. Currently this message is not implemented in any testing of the testing programs so this is primarily based on the documentation and how other messages are implemented.