### PR TITLE
Add StarCraft II SDK link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Third-party SDKs created and maintained by the community.
 - [Generic C# SDK](https://github.com/pandapanda135/CSharp-Neuro-SDK)
 - [Ren'Py SDK](https://github.com/caheuer/neuro-renpy-implementation#for-developers)
 - [RPG Maker VX Ace SDK](https://github.com/Pasu4/rpg-maker-vxa-neuro-sdk)
+- [StarCraft II SDK](https://github.com/ArthurWiese/SC2-Neuro-API-Integration)
 
 ### Tools
 - [Tony](https://github.com/Pasu4/neuro-api-tony) is a graphical testing interface, similar to Randy, but it allows the user to write messages manually.


### PR DESCRIPTION
I created the [StarCraft II SDK](https://github.com/ArthurWiese/SC2-Neuro-API-Integration) for my [custom Wings of Liberty campaign](https://github.com/ArthurWiese/SC2-Neuro-WoL-Integration) (Co-op experience with Neuro and a player)

Supports all Neuro API features (except the voice chat feature, but that's not relevant for this game) and it is extensively tested by myself

Implementation is technically interesting as all communication between Neuro and the game is handled with synchronised writes to a single file